### PR TITLE
Stop using buzzy in Travis build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
+dist: trusty
+sudo: required
 language: c
 compiler:
   - clang
   - gcc
-before_install:
-  # Travis performs a shallow clone, which doesn't fetch tags. We need tags for
-  # Buzzy to build/test the package.
-  - git fetch
-  # Download and install Buzzy
-  - wget https://github.com/redjack/buzzy/releases/download/0.5.0/buzzy_0.5.0_precise_amd64.deb -O buzzy.deb
-  - sudo dpkg -i buzzy.deb
-script: buzzy test
+env:
+  - ARCH=i386
+  - ARCH=amd64
+
+install: .travis/install
+script: .travis/test
+
 
 # In addition to pull requests, always build these branches
 branches:

--- a/.travis/install
+++ b/.travis/install
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+if [ "$TRAVIS_OS_NAME" = linux ]; then
+    sudo apt-get update -qq
+
+    if [ "$ARCH" = i386 ]; then
+        sudo apt-get install gcc-multilib
+    fi
+
+    sudo apt-get install libcork-dev:$ARCH
+    sudo apt-get install check:$ARCH
+else
+    brew install --universal check
+fi

--- a/.travis/test
+++ b/.travis/test
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+mkdir .build
+cd .build
+
+if [ "$TRAVIS_OS_NAME" = linux ]; then
+    if [ "$ARCH" = i386 ]; then
+        ARCH_FLAGS="-m32"
+        export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
+    else
+        ARCH_FLAGS=""
+    fi
+elif [ "$TRAVIS_OS_NAME" = osx ]; then
+    if [ "$ARCH" = i386 ]; then
+        ARCH_FLAGS="-arch i386"
+    else
+        ARCH_FLAGS="-arch x86_64"
+    fi
+fi
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-g -O3 $ARCH_FLAGS"
+make
+make test


### PR DESCRIPTION
Buzzy has some bit-rot, and it'll take some effort to get it working again.  In the meantime, ipset only has a single dependency, which is available in Debian now!