### PR TITLE
Update to latest copy of buzzy

### DIFF
--- a/.buzzy/links.yaml
+++ b/.buzzy/links.yaml
@@ -1,4 +1,3 @@
-- git://github.com/redjack/check.git
 - !git-env
-  url: git://github.com/redjack/libcork.git
-  commit: develop
+  url: git://github.com/dcreager/libcork.git
+  commit: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 language: c
 compiler:
   - clang
@@ -7,7 +9,7 @@ before_install:
   # Buzzy to build/test the package.
   - git fetch
   # Download and install Buzzy
-  - wget https://github.com/redjack/buzzy/releases/download/0.5.0/buzzy_0.5.0_precise_amd64.deb -O buzzy.deb
+  - wget https://github.com/dcreager/buzzy/releases/download/0.6.0/buzzy_0.6.0_trusty_amd64.deb -O buzzy.deb
   - sudo dpkg -i buzzy.deb
 script: buzzy test
 


### PR DESCRIPTION
Buzzy isn't hosted under the redjack repo anymore.  This should cause the Travis tests to start passing again.